### PR TITLE
Fix/num layer

### DIFF
--- a/config/keymap/behaviors.dtsi
+++ b/config/keymap/behaviors.dtsi
@@ -4,14 +4,98 @@
 
 / {
     behaviors {
-        ht_num_func: homerow_mod {
-            compatible = "zmk,behavior-hold-tap";
-            #binding-cells = <2>;
-            flavor = "tap-preferred";
-            tapping-term-ms = <175>; // triggers the hold behavior when the tapping-term-ms has expired
-            quick-tap-ms = <150>; // If you press a tapped hold-tap again within quick-tap-ms milliseconds of the first press, it will always trigger the tap behavior.
-            require-prior-idle-ms = <185>; // like quick-tap-ms however it will apply for any non-modifier key pressed before it
-            bindings = <&kp>, <&kp>;  // hold, tap
+        // ht_num_func: homerow_mod {
+        //     compatible = "zmk,behavior-hold-tap";
+        //     #binding-cells = <2>;
+        //     flavor = "tap-preferred";
+        //     tapping-term-ms = <260>; // triggers the hold behavior when the tapping-term-ms has expired
+        //     quick-tap-ms = <220>; // If you press a tapped hold-tap again within quick-tap-ms milliseconds of the first press, it will always trigger the tap behavior.
+        //     require-prior-idle-ms = <185>; // like quick-tap-ms however it will apply for any non-modifier key pressed before it
+        //     bindings = <&kp>, <&kp>;  // hold, tap
+        // };
+
+        mm_f1: num_or_f1 {
+            compatible    = "zmk,behavior-mod-morph";
+            #binding-cells = <0>;
+            bindings      = <&kp N1>, <&kp F1>;
+            mods          = <MOD_LSFT>;
+        };
+
+        mm_f2: num_or_f2 {
+            compatible    = "zmk,behavior-mod-morph";
+            #binding-cells = <0>;
+            bindings      = <&kp N2>, <&kp F2>;
+            mods          = <MOD_LSFT>;
+        };
+
+        mm_f3: num_or_f3 {
+            compatible    = "zmk,behavior-mod-morph";
+            #binding-cells = <0>;
+            bindings      = <&kp N3>, <&kp F3>;
+            mods          = <MOD_LSFT>;
+        };
+
+        mm_f4: num_or_f4 {
+            compatible    = "zmk,behavior-mod-morph";
+            #binding-cells = <0>;
+            bindings      = <&kp N4>, <&kp F4>;
+            mods          = <MOD_LSFT>;
+        };
+
+        mm_f5: num_or_f5 {
+            compatible    = "zmk,behavior-mod-morph";
+            #binding-cells = <0>;
+            bindings      = <&kp N5>, <&kp F5>;
+            mods          = <MOD_LSFT>;
+        };
+
+        mm_f6: num_or_f6 {
+            compatible    = "zmk,behavior-mod-morph";
+            #binding-cells = <0>;
+            bindings      = <&kp N6>, <&kp F6>;
+            mods          = <MOD_LSFT>;
+        };
+
+        mm_f7: num_or_f7 {
+            compatible    = "zmk,behavior-mod-morph";
+            #binding-cells = <0>;
+            bindings      = <&kp N7>, <&kp F7>;
+            mods          = <MOD_LSFT>;
+        };
+
+        mm_f8: num_or_f8 {
+            compatible    = "zmk,behavior-mod-morph";
+            #binding-cells = <0>;
+            bindings      = <&kp N8>, <&kp F8>;
+            mods          = <MOD_LSFT>;
+        };
+
+        mm_f9: num_or_f9 {
+            compatible    = "zmk,behavior-mod-morph";
+            #binding-cells = <0>;
+            bindings      = <&kp N9>, <&kp F9>;
+            mods          = <MOD_LSFT>;
+        };
+
+        mm_f10: pct_or_f10 {
+            compatible    = "zmk,behavior-mod-morph";
+            #binding-cells = <0>;
+            bindings      = <&kp PRCNT>, <&kp F10>;
+            mods          = <MOD_LSFT>;
+        };
+
+        mm_f11: asterisk_or_f11 {
+            compatible    = "zmk,behavior-mod-morph";
+            #binding-cells = <0>;
+            bindings      = <&kp ASTRK>, <&kp F11>;
+            mods          = <MOD_LSFT>;
+        };
+
+        mm_f12: dot_or_f12 {
+            compatible    = "zmk,behavior-mod-morph";
+            #binding-cells = <0>;
+            bindings      = <&kp DOT>, <&kp F12>;
+            mods          = <MOD_LSFT>;
         };
 
         // Left-hand HRM
@@ -21,7 +105,7 @@
             flavor = "balanced";
             tapping-term-ms = <280>;
             quick-tap-ms = <175>;
-            require-prior-idle-ms = <150>;
+            require-prior-idle-ms = <90>;
             bindings = <&kp>, <&kp>;
             hold-trigger-key-positions = <KEYS_R THUMBS>;
             hold-trigger-on-release;
@@ -34,7 +118,7 @@
             flavor = "balanced";
             tapping-term-ms = <280>;
             quick-tap-ms = <175>;
-            require-prior-idle-ms = <125>;
+            require-prior-idle-ms = <80>;
             bindings = <&kp>, <&kp>;
             hold-trigger-key-positions = <KEYS_L THUMBS>;
             hold-trigger-on-release;
@@ -47,11 +131,19 @@
             bindings = <&lt 7 ESC>, <&mo 6>; // hold, tap, double_tap
         };
 
+        lt_nav: nav_layer_tap {
+            compatible = "zmk,behavior-hold-tap";
+            #binding-cells = <2>;
+            flavor = "tap-preferred";
+            tapping-term-ms = <170>;
+            bindings = <&mo>, <&kp>;
+        };
+
         td_space_nav: td_space {
             compatible = "zmk,behavior-tap-dance";
             #binding-cells = <0>;
-            tapping-term-ms = <120>;
-            bindings = <&lt 2 SPACE>, <&kp SPACE>; // hold, tap, double_tap
+            tapping-term-ms = <110>;
+            bindings = <&lt_nav 2 SPACE>, <&kp SPACE>; // hold, tap, double_tap
         };
 
         mo_clk: mo_click {

--- a/config/keymap/behaviors.dtsi
+++ b/config/keymap/behaviors.dtsi
@@ -106,6 +106,7 @@
             tapping-term-ms = <280>;
             quick-tap-ms = <160>;
             require-prior-idle-ms = <65>;
+            retro-tap;
             bindings = <&kp>, <&kp>;
             hold-trigger-key-positions = <KEYS_R THUMBS>;
         };
@@ -118,6 +119,7 @@
             tapping-term-ms = <280>;
             quick-tap-ms = <160>;
             require-prior-idle-ms = <55>;
+            retro-tap;
             bindings = <&kp>, <&kp>;
             hold-trigger-key-positions = <KEYS_L THUMBS>;
         };

--- a/config/keymap/behaviors.dtsi
+++ b/config/keymap/behaviors.dtsi
@@ -104,8 +104,8 @@
             #binding-cells = <2>;
             flavor = "balanced";
             tapping-term-ms = <280>;
-            quick-tap-ms = <140>;
-            require-prior-idle-ms = <40>;
+            quick-tap-ms = <160>;
+            require-prior-idle-ms = <65>;
             bindings = <&kp>, <&kp>;
             hold-trigger-key-positions = <KEYS_R THUMBS>;
         };
@@ -116,8 +116,8 @@
             #binding-cells = <2>;
             flavor = "balanced";
             tapping-term-ms = <280>;
-            quick-tap-ms = <140>;
-            require-prior-idle-ms = <35>;
+            quick-tap-ms = <160>;
+            require-prior-idle-ms = <55>;
             bindings = <&kp>, <&kp>;
             hold-trigger-key-positions = <KEYS_L THUMBS>;
         };

--- a/config/keymap/behaviors.dtsi
+++ b/config/keymap/behaviors.dtsi
@@ -104,11 +104,10 @@
             #binding-cells = <2>;
             flavor = "balanced";
             tapping-term-ms = <280>;
-            quick-tap-ms = <175>;
-            require-prior-idle-ms = <90>;
+            quick-tap-ms = <140>;
+            require-prior-idle-ms = <40>;
             bindings = <&kp>, <&kp>;
             hold-trigger-key-positions = <KEYS_R THUMBS>;
-            hold-trigger-on-release;
         };
 
         // Right-hand HRM
@@ -117,11 +116,10 @@
             #binding-cells = <2>;
             flavor = "balanced";
             tapping-term-ms = <280>;
-            quick-tap-ms = <175>;
-            require-prior-idle-ms = <80>;
+            quick-tap-ms = <140>;
+            require-prior-idle-ms = <35>;
             bindings = <&kp>, <&kp>;
             hold-trigger-key-positions = <KEYS_L THUMBS>;
-            hold-trigger-on-release;
         };
 
         td_esc_scrl_slow: td_esc_scrl_slow {

--- a/config/keymap/colemak_dh.keymap
+++ b/config/keymap/colemak_dh.keymap
@@ -42,7 +42,7 @@
 // ├───────────────┼────────────────┼────────────────┼─────────────────┼─────────────────┼──────┤  ├──────┼──────────────────┼──────────────────┼─────────────────┼────────────────────────┼─────────────┤
     &kp TAB         &ht_left LCMD A  &ht_left LALT R  &ht_left LSHFT S  &ht_left LCTRL T  &kp G     &kp M  &ht_right RCTRL N  &ht_right RSHFT E  &ht_right LALT I  &ht_right RCMD O  &kp DEL
 // ├───────────────┼────────────────┼────────────────┼─────────────────┼─────────────────┼──────┤  ├──────┼──────────────────┼──────────────────┼─────────────────┼────────────────────────┼─────────────┤
-    &clip_hist      &kp Z            &kp X            &kp C             &kp D             &kp V     &kp K  &kp H              &mm_cm_sc          &mm_pr_col        &mm_qm_ex                 &kp KP_SLASH
+    &clip_hist      &kp Z            &kp X            &kp C             &kp D             &kp V     &kp K  &kp H              &mm_cm_sc          &mm_pr_col        &mm_qm_ex                 &kp FSLH
 // ╰───────────────┴────────────────┴────────────────┼─────────────────┼─────────────────┼──────┤  ├──────┼──────────────────┼──────────────────┴─────────────────┴────────────────────────┴─────────────╯
                                                              &td_esc_scrl_slow   &td_clk  &td_bs     &kp ENTER  &td_space_nav
                                                          // ╰──────────────────┴─────────┴──────╯  ╰──────────┴──────────────╯
@@ -72,10 +72,10 @@
         SYM {
             display-name = "Sym";
             bindings = <
-&none      &none     &none     &kp CARET &kp TILDE       &none         &kp PLUS     &kp AMPS  &kp LBKT  &kp RBKT  &kp PRCNT  &kp BSLH
-&none      &none     &kp LPAR  &kp RPAR  &kp BACKSPACE   &kp UNDER     &kp KP_MINUS &kp GRAVE &kp LBRC  &kp RBRC  &kp ASTRK  &kp PIPE
-&none      &none     &none     &kp HASH  &home_dir       &kp DLLR      &kp EQUAL    &code_blk &kp LT    &kp GT    &kp AT     &kp KP_SLASH
-                                       &none  &trans     &trans         &trans   &trans
+&none  &kp TILDE  &kp DLLR  &kp CARET  &move_line_up    &mc_add_above      &kp AMPS   &kp PLUS     &kp LBKT  &kp RBKT  &kp PRCNT  &kp BSLH
+&none  &kp UNDER  &kp LT    &kp GT     &kp BACKSPACE    &delete_line       &kp GRAVE  &kp KP_MINUS &kp LPAR  &kp RPAR  &kp ASTRK  &kp PIPE
+&none  &home_dir  &none     &kp HASH   &move_line_down  &mc_add_below      &code_blk  &kp EQUAL    &kp LBRC  &kp RBRC  &kp AT     &kp FSLH
+                                       &none  &trans     &trans            &trans   &trans
             >;
         };
 

--- a/config/keymap/colemak_dh.keymap
+++ b/config/keymap/colemak_dh.keymap
@@ -35,6 +35,7 @@
     keymap {
         compatible = "zmk,keymap";
         BASE {
+            display-name = "Base";
             bindings = <
 // ╭───────────────┬────────────────┬────────────────┬─────────────────┬─────────────────┬──────╮  ╭──────┬──────────────────┬──────────────────┬─────────────────┬────────────────────────┬─────────────╮
     &kp C_AC_SEARCH &kp Q            &kp W            &kp F             &kp P             &kp B     &kp J  &kp L              &kp U              &kp Y             &kp APOS                     &td_layers
@@ -49,15 +50,17 @@
         };
 
         NUM {
+            display-name = "Num";
             bindings = <
-&none   &none  &none  &none  &none          &none            &kp PLUS      &ht_num_func F7 N7  &ht_num_func F8 N8  &ht_num_func F9 N9  &ht_num_func F10 PRCNT  &none
-&trans   &none  &none  &none  &kp BACKSPACE  &none            &kp KP_MINUS &ht_num_func F4 N4  &ht_num_func F5 N5  &ht_num_func F6 N6  &ht_num_func F11 ASTRK  &none
-&none    &none  &none  &none  &none          &none            &kp EQUAL    &ht_num_func F1 N1  &ht_num_func F2 N2  &ht_num_func F3 N3  &ht_num_func F12 DOT    &kp KP_SLASH
+&none   &none  &none   &none  &none          &none            &kp PLUS     &mm_f7             &mm_f8             &mm_f9             &mm_f10            &none
+&trans   &none  &none  &none  &kp BACKSPACE  &kp LSHIFT       &kp KP_MINUS &mm_f4             &mm_f5             &mm_f6             &mm_f11            &none
+&none    &none  &kp X  &none  &none          &none            &kp EQUAL    &mm_f1             &mm_f2             &mm_f3             &mm_f12            &kp KP_SLASH
                        &none  &none          &trans           &kp N0     &kp SPACE
             >;
         };
 
         NAV {
+            display-name = "Nav";
             bindings = <
 &none    &msc MOVE_LEFT  &msc MOVE_UP    &none        &msc MOVE_DOWN  &msc MOVE_RIGHT     &detach_session  &create_or_attach  &next_pane   &show_sessions  &sync_panes       &none
 &kp TAB  &mkp MB4        &kp LALT        &kp LSHFT    &kp LCTRL       &mkp MB5            &h_split         &kp LEFT_ARROW     &kp DOWN     &kp UP          &kp RIGHT_ARROW   &none
@@ -67,6 +70,7 @@
         };
 
         SYM {
+            display-name = "Sym";
             bindings = <
 &none      &none     &none     &kp CARET &kp TILDE       &none         &kp PLUS     &kp AMPS  &kp LBKT  &kp RBKT  &kp PRCNT  &kp BSLH
 &none      &none     &kp LPAR  &kp RPAR  &kp BACKSPACE   &kp UNDER     &kp KP_MINUS &kp GRAVE &kp LBRC  &kp RBRC  &kp ASTRK  &kp PIPE
@@ -76,6 +80,7 @@
         };
 
         GAME {
+            display-name = "Game";
             bindings = <
 &kp N1  &kp TAB    &kp Q  &kp W   &kp E      &kp R           &none  &none  &none  &none  &none  &trans
 &kp N2  &kp LCTRL  &kp A  &kp S   &kp D      &kp F           &none  &none  &none  &none  &none  &none
@@ -85,6 +90,7 @@
         };
 
         EXTRAS {
+            display-name = "Xtra";
             bindings = <
 &studio_unlock    &shrug          &lgtm           &gcm            &none           &kp C_BRIGHTNESS_INC    &bt BT_SEL 0  &bt BT_SEL 1    &bt BT_SEL 2       &bt BT_SEL 3  &out OUT_TOG         &bt BT_CLR
 &kp C_SLEEP       &sudo           &none           &none           &none           &kp C_BRIGHTNESS_DEC    &none         &kp C_PREVIOUS  &kp C_PLAY_PAUSE   &kp C_STOP    &kp C_NEXT           &none
@@ -94,6 +100,7 @@
         };
 
         SLOW {
+            display-name = "Slow";
             bindings = <
 &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans
 &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans
@@ -103,6 +110,7 @@
         };
 
         SCROLL {
+            display-name = "Scroll";
             bindings = <
 &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans
 &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans

--- a/config/keymap/macros.dtsi
+++ b/config/keymap/macros.dtsi
@@ -161,7 +161,57 @@
                 , <&macro_release &kp LCTRL &kp LSHFT>
                 ;
         };
-        
+
+        mc_add_above: multicursor_add_above {
+            compatible = "zmk,behavior-macro";
+            #binding-cells = <0>;
+            bindings
+                = <&macro_press &kp LCTRL &kp LALT>
+                , <&macro_tap &kp UP>
+                , <&macro_release &kp LCTRL &kp LALT>
+                ;
+        };
+
+        mc_add_below: multicursor_add_below {
+            compatible = "zmk,behavior-macro";
+            #binding-cells = <0>;
+            bindings
+                = <&macro_press &kp LCTRL &kp LALT>
+                , <&macro_tap &kp DOWN>
+                , <&macro_release &kp LCTRL &kp LALT>
+                ;
+        };
+
+        delete_line: delete_line {
+            compatible = "zmk,behavior-macro";
+            #binding-cells = <0>;
+            bindings
+                = <&macro_press &kp LCTRL &kp LSHFT>
+                , <&macro_tap &kp K>
+                , <&macro_release &kp LCTRL &kp LSHFT>
+                ;
+        };
+
+        move_line_up: move_line_up {
+            compatible = "zmk,behavior-macro";
+            #binding-cells = <0>;
+            bindings
+                = <&macro_press &kp LALT>
+                , <&macro_tap &kp UP>
+                , <&macro_release &kp LALT>
+                ;
+        };
+
+        move_line_down: move_line_down {
+            compatible = "zmk,behavior-macro";
+            #binding-cells = <0>;
+            bindings
+                = <&macro_press &kp LALT>
+                , <&macro_tap &kp DOWN>
+                , <&macro_release &kp LALT>
+                ;
+        };
+
         code_blk: code_blk {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;

--- a/config/keymap/qwerty.keymap
+++ b/config/keymap/qwerty.keymap
@@ -35,6 +35,7 @@
     keymap {
         compatible = "zmk,keymap";
         BASE {
+            display-name = "Base";
             bindings = <
 // ╭───────────────┬────────────────┬────────────────┬─────────────────┬─────────────────┬──────╮  ╭──────┬──────────────────┬──────────────────┬─────────────────┬────────────────────────┬─────────────╮
     &kp C_AC_SEARCH &kp Q            &kp W            &kp E             &kp R             &kp T     &kp Y  &kp U              &kp I              &kp O             &kp P                     &td_layers
@@ -49,15 +50,17 @@
         };
 
         NUM {
+            display-name = "Num";
             bindings = <
-&none   &none  &none  &none  &none          &none            &kp PLUS      &ht_num_func F7 N7  &ht_num_func F8 N8  &ht_num_func F9 N9  &ht_num_func F10 PRCNT  &none
-&trans   &none  &none  &none  &kp BACKSPACE  &none            &kp KP_MINUS &ht_num_func F4 N4  &ht_num_func F5 N5  &ht_num_func F6 N6  &ht_num_func F11 ASTRK  &none
-&none    &none  &none  &none  &none          &none            &kp EQUAL    &ht_num_func F1 N1  &ht_num_func F2 N2  &ht_num_func F3 N3  &ht_num_func F12 DOT    &kp KP_SLASH
+&none   &none  &none   &none  &none          &none            &kp PLUS     &mm_f7             &mm_f8             &mm_f9             &mm_f10            &none
+&trans   &none  &none  &none  &kp BACKSPACE  &kp LSHIFT       &kp KP_MINUS &mm_f4             &mm_f5             &mm_f6             &mm_f11            &none
+&none    &none  &kp X  &none  &none          &none            &kp EQUAL    &mm_f1             &mm_f2             &mm_f3             &mm_f12            &kp KP_SLASH
                        &none  &none          &trans           &kp N0     &kp SPACE
             >;
         };
 
         NAV {
+            display-name = "Nav";
             bindings = <
 &none    &msc MOVE_LEFT  &msc MOVE_UP    &none        &msc MOVE_DOWN  &msc MOVE_RIGHT     &detach_session  &create_or_attach  &next_pane   &show_sessions  &sync_panes       &none
 &kp TAB  &mkp MB4        &kp LALT        &kp LSHFT    &kp LCTRL       &mkp MB5            &h_split         &kp LEFT_ARROW     &kp DOWN     &kp UP          &kp RIGHT_ARROW   &none
@@ -67,6 +70,7 @@
         };
 
         SYM {
+            display-name = "Sym";
             bindings = <
 &none      &none     &none     &kp CARET &kp TILDE       &none         &kp PLUS     &kp AMPS  &kp LBKT  &kp RBKT  &kp PRCNT  &kp BSLH
 &none      &none     &kp LPAR  &kp RPAR  &kp BACKSPACE   &kp UNDER     &kp KP_MINUS &kp GRAVE &kp LBRC  &kp RBRC  &kp ASTRK  &kp PIPE
@@ -76,6 +80,7 @@
         };
 
         GAME {
+            display-name = "Game";
             bindings = <
 &kp N1  &kp TAB    &kp Q  &kp W   &kp E      &kp R           &none  &none  &none  &none  &none  &trans
 &kp N2  &kp LCTRL  &kp A  &kp S   &kp D      &kp F           &none  &none  &none  &none  &none  &none
@@ -85,6 +90,7 @@
         };
 
         EXTRAS {
+            display-name = "Xtra";
             bindings = <
 &studio_unlock    &shrug          &lgtm           &gcm            &none           &kp C_BRIGHTNESS_INC    &bt BT_SEL 0  &bt BT_SEL 1    &bt BT_SEL 2       &bt BT_SEL 3  &out OUT_TOG         &bt BT_CLR
 &kp C_SLEEP       &sudo           &none           &none           &none           &kp C_BRIGHTNESS_DEC    &none         &kp C_PREVIOUS  &kp C_PLAY_PAUSE   &kp C_STOP    &kp C_NEXT           &none
@@ -94,6 +100,7 @@
         };
 
         SLOW {
+            display-name = "Slow";
             bindings = <
 &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans
 &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans
@@ -103,6 +110,7 @@
         };
 
         SCROLL {
+            display-name = "Scroll";
             bindings = <
 &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans
 &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans

--- a/config/keymap/qwerty.keymap
+++ b/config/keymap/qwerty.keymap
@@ -42,7 +42,7 @@
 // ├───────────────┼────────────────┼────────────────┼─────────────────┼─────────────────┼──────┤  ├──────┼──────────────────┼──────────────────┼─────────────────┼────────────────────────┼─────────────┤
     &kp TAB         &ht_left LCMD A  &ht_left LALT S  &ht_left LSHFT D  &ht_left LCTRL F  &kp G     &kp H  &ht_right RCTRL J  &ht_right RSHFT K  &ht_right LALT L  &ht_right RCMD SEMICOLON  &kp DEL
 // ├───────────────┼────────────────┼────────────────┼─────────────────┼─────────────────┼──────┤  ├──────┼──────────────────┼──────────────────┼─────────────────┼────────────────────────┼─────────────┤
-    &clip_hist      &kp Z            &kp X            &kp C             &kp V             &kp B     &kp N  &kp M              &mm_cm_sc          &mm_pr_col        &mm_qm_ex                 &kp KP_SLASH
+    &clip_hist      &kp Z            &kp X            &kp C             &kp V             &kp B     &kp N  &kp M              &mm_cm_sc          &mm_pr_col        &mm_qm_ex                 &kp FSLH
 // ╰───────────────┴────────────────┴────────────────┼─────────────────┼─────────────────┼──────┤  ├──────┼──────────────────┼──────────────────┴─────────────────┴────────────────────────┴─────────────╯
                                                              &td_esc_scrl_slow   &td_clk  &td_bs     &kp ENTER  &td_space_nav
                                                          // ╰──────────────────┴─────────┴──────╯  ╰──────────┴──────────────╯
@@ -72,10 +72,10 @@
         SYM {
             display-name = "Sym";
             bindings = <
-&none      &none     &none     &kp CARET &kp TILDE       &none         &kp PLUS     &kp AMPS  &kp LBKT  &kp RBKT  &kp PRCNT  &kp BSLH
-&none      &none     &kp LPAR  &kp RPAR  &kp BACKSPACE   &kp UNDER     &kp KP_MINUS &kp GRAVE &kp LBRC  &kp RBRC  &kp ASTRK  &kp PIPE
-&none      &none     &none     &kp HASH  &home_dir       &kp DLLR      &kp EQUAL    &code_blk &kp LT    &kp GT    &kp AT     &kp KP_SLASH
-                                       &none  &trans     &trans         &trans   &trans
+&none  &kp TILDE  &kp DLLR  &kp CARET  &move_line_up    &mc_add_above      &kp AMPS   &kp PLUS     &kp LBKT  &kp RBKT  &kp PRCNT  &kp BSLH
+&none  &kp UNDER  &kp LT    &kp GT     &kp BACKSPACE    &delete_line       &kp GRAVE  &kp KP_MINUS &kp LPAR  &kp RPAR  &kp ASTRK  &kp PIPE
+&none  &home_dir  &none     &kp HASH   &move_line_down  &mc_add_below      &code_blk  &kp EQUAL    &kp LBRC  &kp RBRC  &kp AT     &kp FSLH
+                                       &none  &trans     &trans            &trans   &trans
             >;
         };
 

--- a/scripts/convert_keymap.py
+++ b/scripts/convert_keymap.py
@@ -57,10 +57,10 @@ def main():
 
     # 1) Precisely capture only the BASE bindings block
     base_pattern = re.compile(
-        r'(^\s*BASE\s*\{\s*bindings\s*=\s*<\s*\n)'  # start of BASE layer
-        r'(.*?)'                                    # everything inside
-        r'(^\s*>\s*;)',                             # closing >;
-        re.MULTILINE | re.DOTALL
+        r'(^\s*BASE\s*\{[\s\S]*?bindings\s*=\s*<\s*(?:\r?\n))'  # BASE header through bindings line
+        r'([\s\S]*?)'                                                 # contents of bindings block
+        r'(^\s*>\s*;)',                                               # closing >;
+        re.MULTILINE
     )
 
     # 2) Regex to match any all-caps token (your keycodes)


### PR DESCRIPTION
- Moved the function keys to a mod morph on the num layer to increase switch time from letters to numbers
- Updated the keymap conversion script to better handle finding the BASE layer
- Tweaked the space/NAV layer timing to prevent skipping the first character after a space when typing quickly.
- Shortened the hrm timing windows so holds resolve even when they are hit right after rapid backspacing.
- Added retro-tap to both home-row mod behaviors so a quick release still resolves to the tap even if the opposite hand is pressed
- Swapped 'KP_SLASH' with 'FSLH' so that keyboard shortcuts, like commenting out code, will work again.