### PR TITLE
Fix build failure on second run: set core.fileMode=false before west update

### DIFF
--- a/local-build/build_setup.sh
+++ b/local-build/build_setup.sh
@@ -65,7 +65,7 @@ fi
 
 # Set permissions so users can delete them in their own environment
 echo "Setting permissions on ZMK resources..."
-chmod -R 777 .west zmk zephyr modules zmk-pmw3610-driver prospector-zmk-module
+chmod -R a+rwX .west zmk zephyr modules zmk-pmw3610-driver prospector-zmk-module
 
 # # Debug: confirm checkout
 # echo "    West workspace ready. Project structure:"

--- a/local-build/build_setup.sh
+++ b/local-build/build_setup.sh
@@ -26,6 +26,8 @@ fi
 if [[ "$SKIP_WEST_UPDATE" == "true" ]]; then
     echo "Skipping west update; using current local module checkouts."
 else
+    # Ignore file mode changes before updating (chmod -R 777 later would dirty every file otherwise)
+    west forall -c 'git config core.fileMode false' 2>/dev/null || true
     echo "Updating west modules..."
     west update
 fi


### PR DESCRIPTION
## Summary

- `build_setup.sh` runs `chmod -R 777 zmk zephyr modules ...` to ensure the Docker container user can write to the bind-mounted directories
- This sets the executable bit on every file in those repos (mode `100644` → `100755`)
- On the **next** build, `west update` detects these mode changes as "local modifications" and refuses to checkout the target commit, failing with: `error: Your local changes to the following files would be overwritten by checkout`
- Fix: run `west forall -c 'git config core.fileMode false'` before `west update` so git ignores file mode changes in all west-managed module repos

## Test plan

- [ ] Run `docker compose -f local-build/docker-compose.yml run --rm builder` twice in a row — second run should no longer fail at `west update`
- [ ] Firmware artifacts are produced correctly on both runs